### PR TITLE
relax user email constraint

### DIFF
--- a/internal/provider/validation.go
+++ b/internal/provider/validation.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"net/mail"
 	"regexp"
-	"strings"
 	"time"
 
 	"github.com/hashicorp/go-cty/cty"
@@ -35,10 +34,6 @@ func validateStringIsEmail() schema.SchemaValidateDiagFunc {
 
 		if address.Name != "" {
 			return diag.Errorf("mail: must not contain display name")
-		}
-
-		if !strings.Contains(strings.Split(address.Address, "@")[1], ".") {
-			return diag.Errorf("mail: missing '.' in address domain")
 		}
 
 		var diags diag.Diagnostics

--- a/internal/provider/validation_test.go
+++ b/internal/provider/validation_test.go
@@ -33,9 +33,7 @@ func TestStringIsDuration(t *testing.T) {
 func TestStringIsEmail(t *testing.T) {
 	cases := map[string]diag.Diagnostics{
 		"admin@example.com": nil,
-		"admin@example": diag.Diagnostics{
-			{Summary: "mail: missing '.' in address domain"},
-		},
+		"admin@example":     nil,
 		"admin": diag.Diagnostics{
 			{Summary: "mail: missing '@' or angle-addr"},
 		},


### PR DESCRIPTION
user email may not contain a full domain so relax the constraint so those users can be referenced by name. specifically, since https://github.com/infrahq/helm-charts the initial admin user name is `admin@local`