### PR TITLE
relax group name constraint to printable characters

### DIFF
--- a/docs/resources/group.md
+++ b/docs/resources/group.md
@@ -23,7 +23,7 @@ resource "infra_group" "example" {
 
 ### Required
 
-- `name` (String) The group's name. Group names may include letters (uppercase and lowercase), numbers, underscores `_`, hyphens `-`, and periods `.`.
+- `name` (String) The group's name.
 
 ### Read-Only
 

--- a/internal/provider/resource_grant.go
+++ b/internal/provider/resource_grant.go
@@ -59,12 +59,11 @@ func resourceGrant() *schema.Resource {
 				},
 			},
 			"group_name": {
-				Description:      "The name of the group to assign this grant.",
-				Type:             schema.TypeString,
-				Optional:         true,
-				Computed:         true,
-				ForceNew:         true,
-				ValidateDiagFunc: validateStringIsName(),
+				Description: "The name of the group to assign this grant.",
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
 				ExactlyOneOf: []string{
 					"user_id", "user_name", "group_id", "group_name",
 				},

--- a/internal/provider/resource_group.go
+++ b/internal/provider/resource_group.go
@@ -31,11 +31,10 @@ func resourceGroup() *schema.Resource {
 				Computed:    true,
 			},
 			"name": {
-				Description:      "The group's name. Group names may include letters (uppercase and lowercase), numbers, underscores `_`, hyphens `-`, and periods `.`.",
-				Type:             schema.TypeString,
-				Required:         true,
-				ForceNew:         true,
-				ValidateDiagFunc: validateStringIsName(),
+				Description: "The group's name.",
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
 			},
 		},
 	}

--- a/internal/provider/resource_group_membership.go
+++ b/internal/provider/resource_group_membership.go
@@ -54,12 +54,11 @@ func resourceGroupMembership() *schema.Resource {
 				},
 			},
 			"group_name": {
-				Description:      "The name of the group to assign to the user.",
-				Type:             schema.TypeString,
-				Optional:         true,
-				Computed:         true,
-				ForceNew:         true,
-				ValidateDiagFunc: validateStringIsName(),
+				Description: "The name of the group to assign to the user.",
+				Type:        schema.TypeString,
+				Optional:    true,
+				Computed:    true,
+				ForceNew:    true,
 				ExactlyOneOf: []string{
 					"group_id", "group_name",
 				},

--- a/internal/provider/resource_group_test.go
+++ b/internal/provider/resource_group_test.go
@@ -12,10 +12,11 @@ import (
 )
 
 func TestAccResourceGroup(t *testing.T) {
-	var id1, id2 uid.ID
+	var id1, id2, id3 uid.ID
 
 	name1 := randomName()
 	name2 := randomName()
+	nameWithSpace := fmt.Sprintf("%s %s", randomName(), randomName())
 
 	resourceName := "infra_group.test"
 
@@ -36,6 +37,14 @@ func TestAccResourceGroup(t *testing.T) {
 					resource.TestCheckResourceAttrWith(resourceName, "id", testCheckResourceAttrWithID(&id2)),
 					resource.TestCheckResourceAttr(resourceName, "name", name2),
 					testAccCheckIDChanged(&id1, &id2),
+				),
+			},
+			{
+				Config: testAccResourceGroup(nameWithSpace),
+				Check: resource.ComposeTestCheckFunc(
+					resource.TestCheckResourceAttrWith(resourceName, "id", testCheckResourceAttrWithID(&id3)),
+					resource.TestCheckResourceAttr(resourceName, "name", nameWithSpace),
+					testAccCheckIDChanged(&id2, &id3),
 				),
 			},
 		},


### PR DESCRIPTION
Group name constraint is too strict which block referencing completely valid names, such as group name with spaces